### PR TITLE
ci: 也可以从shell中获取环境变量, 使netlify构建成功

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -8,8 +8,6 @@ const env = Object.assign({}, require('dotenv').config().parsed, {
   OSS_REGION: process.env.OSS_REGION
 })
 
-console.log(env)
-
 const demos = glob.sync('docs/!(basic).md')
 const demoSections = demos.map(filePath => ({
   name: path.basename(filePath, '.md'),

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,6 +1,14 @@
 const {VueLoaderPlugin} = require('vue-loader')
 const path = require('path')
 const glob = require('glob')
+const env = Object.assign({}, require('dotenv').config().parsed, {
+  OSS_KEY: process.env.OSS_KEY,
+  OSS_SECRET: process.env.OSS_SECRET,
+  OSS_BUCKET: process.env.OSS_BUCKET,
+  OSS_REGION: process.env.OSS_REGION
+})
+
+console.log(env)
 
 const demos = glob.sync('docs/!(basic).md')
 const demoSections = demos.map(filePath => ({
@@ -51,7 +59,7 @@ module.exports = {
     plugins: [
       new VueLoaderPlugin(),
       new (require('webpack')).DefinePlugin({
-        'process.env': JSON.stringify(require('dotenv').config().parsed)
+        'process.env': JSON.stringify(env)
       })
     ]
   }


### PR DESCRIPTION
## Why
解决netlify构建无法获取环境变量问题

## How
在dotenv基础上，增加从process.env获取环境变量的方式

