### PR TITLE
fix: 图片与按钮不对齐 close #39

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -588,6 +588,7 @@ $active-color = #5d81f9
   .upload-area {
     cursor: pointer;
     display: inline-block;
+    vertical-align: top;
   }
   .upload-tip {
     margin-top: 8px;


### PR DESCRIPTION
- fix: 图片与按钮没有对齐 

## Why
在 thinkpad e490  windows  chrome 下图片与按钮没有对齐
https://github.com/FEMessage/upload-to-ali/issues/39

## How
给按钮增加vertical-align: top;

## Test
1 在宽度足够时能对齐
2 在宽度不足被挤到下一行时也能对齐
