### PR TITLE
docs: 调整`slot`使得styleguidist可正确扫描

### DIFF
--- a/src/upload-to-ali.md
+++ b/src/upload-to-ali.md
@@ -1,7 +1,0 @@
-## API 补充
-
-### Slots
-
-| Slot        | 说明               |
-| ----------- | ------------------ |
-| placeholder | 自定义 placeholder |

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -26,18 +26,22 @@
       <!--@slot 自定义上传区域，会覆盖 slot=spinner、slot=placeholder-->
       <slot>
         <div class="upload-box">
-          <!--@slot 自定义loading内容，默认类似 element-ui 的 v-loading -->
-          <slot name="spinner" v-if="uploading">
-            <div class="upload-loading">
-              <svg class="circular" viewBox="25 25 50 50">
-                <circle class="path" cx="50" cy="50" r="20" fill="none"></circle>
-              </svg>
-            </div>
-          </slot>
-          <!--@slot 自定义placeholder内容 -->
-          <slot name="placeholder" v-else>
-            <div class="upload-placeholder"></div>
-          </slot>
+          <template v-if="uploading">
+            <!--@slot 自定义loading内容，默认类似 element-ui 的 v-loading -->
+            <slot name="spinner">
+              <div class="upload-loading">
+                <svg class="circular" viewBox="25 25 50 50">
+                  <circle class="path" cx="50" cy="50" r="20" fill="none"></circle>
+                </svg>
+              </div>
+            </slot>
+          </template>
+          <template v-else>
+            <!--@slot 自定义placeholder内容 -->
+            <slot name="placeholder">
+              <div class="upload-placeholder"></div>
+            </slot>
+          </template>
         </div>
       </slot>
     </div>
@@ -290,6 +294,8 @@ export default {
     /**
      * 手动触发选择文件事件
      * @public
+     * @param {boolean} shouldStore 介绍
+     * @param {string} filename 文件名
      */
     selectFiles() {
       if (!this.canUpload) {

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -294,8 +294,6 @@ export default {
     /**
      * 手动触发选择文件事件
      * @public
-     * @param {boolean} shouldStore 介绍
-     * @param {string} filename 文件名
      */
     selectFiles() {
       if (!this.canUpload) {


### PR DESCRIPTION
## Why

slot不能有if-else, 否则无法通过注释生成文档

调整无需写一个api补充文件, 让styleguidist扫描更直观

### 修改前

![image](https://user-images.githubusercontent.com/19513289/59988746-cbb95300-966e-11e9-9cc6-29aacae08491.png)

### 修改后

![image](https://user-images.githubusercontent.com/19513289/59988724-b93f1980-966e-11e9-80e3-0639c11b31ef.png)
