### PR TITLE
feat: 增加beforeUpload钩子函数

### DIFF
--- a/docs/before-upload.md
+++ b/docs/before-upload.md
@@ -1,0 +1,33 @@
+使用 beforeUpload 自定义上传前检查。比如检查图片的尺寸
+
+```vue
+<template>
+  <upload-to-ali v-model="url" :before-upload="beforeUpload" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: ''
+    }
+  },
+  methods: {
+    beforeUpload(files) {
+      return Promise.all(
+        Array.from(files)
+          .filter(f => /image\/.*/.test(f.type))
+          .map(f => createImageBitmap(f))
+      )
+        .then(imgs => {
+          for (let i = 0; i < imgs.length; i++) {
+            if (imgs[i].width > 30) {
+              alert('图片过宽！' + imgs[i].width)
+              return Promise.reject()
+            }
+          }
+        })
+    }
+  }
+}
+</script>
+```

--- a/docs/before-upload.md
+++ b/docs/before-upload.md
@@ -1,4 +1,5 @@
-使用 beforeUpload 自定义上传前检查。比如检查图片的尺寸
+使用 beforeUpload 自定义上传前检查。比如检查图片的尺寸。
+Promise.reject()阻止上传，返回Promise.resolve()则可以上传
 
 ```vue
 <template>

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -207,6 +207,17 @@ export default {
       default(url) {
         this.previewUrl = url
       }
+    },
+    /**
+     * upload前的钩子函数，传入选择的文件，FileList类型。
+     * 要求返回一个promise，resolved则继续upload，rejected则停止上传。
+     * 调用时机在size和accept检验之前。
+     */
+    beforeUpload: {
+      type: Function,
+      default() {
+        return Promise.resolve()
+      }
     }
   },
   data() {
@@ -287,6 +298,12 @@ export default {
       let currentUploads = []
 
       if (!files.length) return
+
+      try {
+        await this.beforeUpload(files)
+      } catch (e) {
+        return
+      }
 
       if (files.some(i => i.size > this.size * oneKB)) {
         alert(`请选择${this.size}KB内的文件！`)


### PR DESCRIPTION
## Why
用户希望在上传前对上传的文件进行更定制化的检查

## How
增加一个钩子函数，传入用户选择的FileList，根据钩子函数的返回结果判断是否继续上传

## Test
1. 查看https://deploy-preview-44--upload-to-ali.netlify.com/#!/before-upload/1
2. 上传一张宽度大于30的图片