### PR TITLE
fix: 图片与按钮没有对齐

### DIFF
--- a/src/components/draggable-list.vue
+++ b/src/components/draggable-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition-group name="draggable-list">
+  <transition-group name="draggable-list" tag="div" class="draggable-list">
     <slot/>
   </transition-group>
 </template>
@@ -64,4 +64,7 @@ export default {
 
 .ghost
   opacity 0.5
+
+.draggable-list
+  display inline-block
 </style>

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -588,6 +588,7 @@ $active-color = #5d81f9
   .upload-area {
     cursor: pointer;
     display: inline-block;
+    vertical-align: top;
   }
   .upload-tip {
     margin-top: 8px;


### PR DESCRIPTION
## Why
- 图片列表均为行内元素，预览图片区存在 margin，撑开容器
- 发现另外一个问题：行元素嵌套块元素，语义化问题

## How
- 上传区添加`vertical-align: top`
  - 原因：图片存在下边距，故对齐使用`top`而不是`bottom`
- `transition-group`使用标签`div`

## Test
### before
![image](https://user-images.githubusercontent.com/21327913/59989190-ab8a9380-9670-11e9-89d4-f7bf32ca1fac.png)

### after
![image](https://user-images.githubusercontent.com/21327913/59989224-ca892580-9670-11e9-80db-30e46b8a10dc.png)

