### PR TITLE
fix: 多次上传同一张不符合的文件，只有第一次有提示

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -322,14 +322,18 @@ export default {
 
       if (!files.length) return
 
+      const reset = () => (e.target.value = '')
+
       try {
         await this.beforeUpload(files)
       } catch (e) {
+        reset()
         return
       }
 
       if (files.some(i => i.size > this.size * oneKB)) {
         alert(`请选择${this.size}KB内的文件！`)
+        reset()
         return
       }
 
@@ -342,10 +346,10 @@ export default {
           : files.some(i => this.accept.indexOf(i.type) === -1))
       ) {
         alert('文件格式有误！')
+        reset()
         return
       }
 
-      const reset = () => (e.target.value = '')
       this.uploading = true
 
       const max = this.multiple ? this.max : 1


### PR DESCRIPTION
close #42 

- fix: 多次上传同一张不符合的文件，只有第一次有提示

## Why
多次上传同一张不符合的文件，只有第一次有提示，后面再次上传就无任何反应。

## How
上传失败的情况（文件格式不对，大小不对等），清空 input 的 value

![image](https://user-images.githubusercontent.com/26338853/60485439-9399bc00-9ccf-11e9-9996-ef14748db277.png)

## Test
多次上传同一超过大小的文件，每次都有提示
多次上传同一格式不符的文件，每次都有提示
使用 before-upload 钩子，多次上传同一 不符的 文件  每次都能触发此钩子

Before
![before](https://user-images.githubusercontent.com/26338853/60485472-b330e480-9ccf-11e9-8726-69533575c516.gif)

After
![after](https://user-images.githubusercontent.com/26338853/60485483-bc21b600-9ccf-11e9-9622-d03fe1515d23.gif)

