### PR TITLE
fix: 删除文件时报错

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -2,7 +2,7 @@
   <div class="upload-to-oss" title="粘贴或拖拽即可上传图片;支持拖拽排序" :class="{'upload-to-oss--highlight': isHighlight}">
     <!--图片的展示区域-->
     <draggable-list v-if="!$slots.default" v-model="uploadList">
-      <div v-for="url in uploadList" :key="url" :class="['upload-item', {'is-preview': preview}]">
+      <div v-for="(url, index) in uploadList" :key="url" :class="['upload-item', {'is-preview': preview}]">
         <i
           title="删除"
           v-if="!disabled"


### PR DESCRIPTION
close #46
 
- fix: A bug fix

## Why
删除已上传文件时报错: index is not defined；在 delete 事件中取不到删除文件的 index

## How
在 v-for 循环图片里定义 index

![image](https://user-images.githubusercontent.com/26338853/60488876-a1ead680-9cd5-11e9-9da3-10285a8011f2.png)


## Test
在 单文件 与 多文件上传模式下，删除已上传文件，不报错，并且在 delete 事件中能取得删除文件的index

## Before After
- Before
![before](https://user-images.githubusercontent.com/26338853/60489119-276e8680-9cd6-11e9-97b3-d2b816c4b4c3.gif)

- After
![after](https://user-images.githubusercontent.com/26338853/60489173-44a35500-9cd6-11e9-8ce2-1091b49a1c5d.gif)

