### PR TITLE
fix: 处理文件名中的非法字符

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -384,14 +384,20 @@ export default {
             // 协议无关
             let filename = doubleSlash
 
+            // Fix: 处理文件名中的非法字符, eg: +, %, &, #...
+            const validName = res.name
+              .split('/')
+              .map(i => encodeURIComponent(i))
+              .join('/')
+
             if (this.customDomain) {
               if (this.customDomain.indexOf(doubleSlash) > -1)
-                filename = `${this.customDomain}/${res.name}`
-              else filename += `${this.customDomain}/${res.name}`
+                filename = `${this.customDomain}/${validName}`
+              else filename += `${this.customDomain}/${validName}`
             } else
-              filename += `${this.bucket}.${this.region}.aliyuncs.com/${
-                res.name
-              }`
+              filename += `${this.bucket}.${
+                this.region
+              }.aliyuncs.com/${validName}`
             this.$emit(
               'input',
               this.multiple ? this.uploadList.concat(filename) : filename


### PR DESCRIPTION
fix: fixes #67  处理文件名中的非法字符

## Why
文件名中若包含'+, %, &, #'等URL非法字符，在上传至oss后并不会被转义，会造成预览图无法显示。

## How
1. 上传前不做检查，按原文件名上传
2. 上传后拼接url时，增加转义处理

## test

- before
![image](https://user-images.githubusercontent.com/9384365/60897730-28d21d00-a29b-11e9-8ca4-bb8f0f6ade75.png)

- after
![image](https://user-images.githubusercontent.com/9384365/60898809-042a7500-a29c-11e9-85a8-7d2dfd578743.png)
