### PR TITLE
docs: 补充在vue-cli3项目中使用的场景

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -83,6 +83,20 @@ OSS_CUSTOM_DOMAIN=cdn.xxx.com
 
 `dotenv` document reference [https://www.npmjs.com/package/dotenv](https://www.npmjs.com/package/dotenv)
 
+### vue-cli3
+
+vue-cli3 offers an easy solution to replace [process.env](https://cli.vuejs.org/zh/guide/mode-and-env.html#%E6%A8%A1%E5%BC%8F), but it requires a pattern(VUE*APP*\*) to inject in client side. So we need to use `dotenv-webpack`'s solution.
+
+```js
+// vue.config.js
+const Dotenv = require('dotenv-webpack')
+module.exports = {
+  configureWebpack: {
+    plugins: [new Dotenv()]
+  }
+}
+```
+
 [⬆Back to Top](#table-of-contents)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ OSS_CUSTOM_DOMAIN=cdn.xxx.com
 
 `dotenv` 文档参考 https://www.npmjs.com/package/dotenv
 
+### vue-cli3
+
+vue-cli3 提供了简便的方案替换[环境变量](https://cli.vuejs.org/zh/guide/mode-and-env.html#%E6%A8%A1%E5%BC%8F)，但无法在客户端注入。这个场景需要结合[dotenv-webpack]插件。
+
+```js
+// vue.config.js
+const Dotenv = require('dotenv-webpack')
+module.exports = {
+  configureWebpack: {
+    plugins: [new Dotenv()]
+  }
+}
+```
+
 [⬆ Back to Top](#table-of-contents)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ OSS_CUSTOM_DOMAIN=cdn.xxx.com
 
 ### vue-cli3
 
-vue-cli3 提供了简便的方案替换[环境变量](https://cli.vuejs.org/zh/guide/mode-and-env.html#%E6%A8%A1%E5%BC%8F)，但无法在客户端注入。这个场景需要结合[dotenv-webpack]插件。
+vue-cli3 提供了简便的方案替换[环境变量](https://cli.vuejs.org/zh/guide/mode-and-env.html#%E6%A8%A1%E5%BC%8F)，但无法在客户端注入。这个场景需要结合`dotenv-webpack`插件。
 
 ```js
 // vue.config.js


### PR DESCRIPTION
## Why
有人反馈，无法简单在main.js里调用`require('dotenv').config()`来注入环境变量，vuc-cli3有自己的覆写操作。

## Test
已在项目中测试过

## Docs
解决方案补充到README中
