### PR TITLE
feat: 支持定制上传提示信息 `title`

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -2,7 +2,7 @@
   <section>
     <div
       class="upload-to-oss"
-      title="粘贴或拖拽即可上传图片;支持拖拽排序"
+      :title="title"
       :class="{'upload-to-oss--highlight': isHighlight}"
     >
       <!--图片的展示区域-->
@@ -248,6 +248,13 @@ export default {
           this.previewUrl = url
         }
       }
+    },
+    /**
+     * 上传区域鼠标悬停提示内容
+     */
+    title: {
+      type: String,
+      default: '粘贴或拖拽即可上传图片;支持拖拽排序'
     },
     /**
      * upload前的钩子函数，传入选择的文件，FileList类型。


### PR DESCRIPTION
close #96


<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why

- 项目某部分设定为只能上传文件, 但提示仍然可上传图片, 显得怪异.

## How

1. 添加 prop.title
2. 默认为 粘贴或拖拽即可上传图片;支持拖拽排序

## Test

### Before

![title-dead](https://user-images.githubusercontent.com/53422750/66450174-1cbc4e00-ea8a-11e9-9826-039942b26217.jpg)

### After

![title](https://user-images.githubusercontent.com/53422750/66450177-21810200-ea8a-11e9-80cd-b6db85d9e256.jpg)

```html
<upload-to-ali v-model="url" title="现在只能上传 zip 文件" />
```