### PR TITLE
feat(http-request): 可自定义上传函数

### DIFF
--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -2,14 +2,14 @@
 
 ```vue
 <template>
-	<upload-to-ali v-model="url" :http-request="myUpload" />
+	<upload-to-ali multiple v-model="url" :http-request="myUpload" />
 </template>
 
 <script>
 export default {
   data() {
     return {
-      url: ''
+      url: []
     }
   },
   methods: {

--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -20,8 +20,8 @@ export default {
         setTimeout(() => {
           resolve(url)
         }, 2000)
-  		})
-  	}
+      })
+    }
   }
 }
 

--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -1,0 +1,33 @@
+覆盖默认的上传行为，可以自定义上传的实现
+
+```vue
+<template>
+	<upload-to-ali v-model="url" :http-request="myUpload" />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      url: ''
+    }
+  },
+  methods: {
+    myUpload(file) {
+      const url = ajax(file)
+
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(url)
+        }, 2000)
+  		})
+  	}
+  }
+}
+
+// 模拟 Ajax
+function ajax() {
+	return '\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg'
+}
+</script>
+```

--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -14,8 +14,6 @@ export default {
   },
   methods: {
     myUpload(file) {
-      const url = ajax(file)
-
       return new Promise(resolve => {
         setTimeout(() => {
           resolve('\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg')

--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -18,16 +18,11 @@ export default {
 
       return new Promise(resolve => {
         setTimeout(() => {
-          resolve(url)
+          resolve('\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg')
         }, 2000)
       })
     }
   }
-}
-
-// 模拟 Ajax
-function ajax() {
-	return '\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg'
 }
 </script>
 ```

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -411,7 +411,7 @@ export default {
 
         if (this.httpRequest) {
           try {
-            const url = await this.httpRequest(e, file)
+            const url = await this.httpRequest(file)
             if (typeof url === 'string' && /^(https?:)?\/\//.test(url)) {
               this.$emit(
                 'input',

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -410,13 +410,19 @@ export default {
         key = `${name.substring(0, pos)}-${new Date().getTime()}${suffix}`
 
         if (this.httpRequest) {
-          await this.httpRequest(e, file).then(url => {
+          const url = await this.httpRequest(e, file)
+
+          if (typeof url === 'string' && /^(https?:)?\/\//.test(url)) {
             this.$emit(
               'input',
               this.multiple ? this.uploadList.concat(url) : url
             )
             currentUploads.push(url)
-          })
+          } else {
+            console.error(
+              `\`Promise.resolve\` 接收的参数应该是超链接(url), 当前为 ${typeof url}.`
+            )
+          }
         } else {
           await this.client
             .multipartUpload(this.dir + key, file, this.uploadOptions)

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -290,18 +290,6 @@ export default {
     }
   },
   mounted() {
-    if (
-      !this.region ||
-      !this.bucket ||
-      !this.accessKeyId ||
-      !this.accessKeySecret
-    ) {
-      console.error(
-        '必要参数不能为空: region bucket accessKeyId accessKeySecret'
-      )
-      return
-    }
-
     if (this.accept && !mimeTypeFullRegex.test(this.accept)) {
       console.warn(
         '请设置正确的`accept`属性, 可参考:',
@@ -313,6 +301,20 @@ export default {
   },
   methods: {
     newClient() {
+      if (this.httpRequest) return
+
+      if (
+        !this.region ||
+        !this.bucket ||
+        !this.accessKeyId ||
+        !this.accessKeySecret
+      ) {
+        console.error(
+          '必要参数不能为空: region bucket accessKeyId accessKeySecret'
+        )
+        return
+      }
+
       // https://help.aliyun.com/document_detail/32069.html?spm=a2c4g.11186623.6.801.LllSVA
       this.client = new AliOSS({
         region: this.region,

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -426,13 +426,7 @@ export default {
           } catch (error) {
             this.uploading = false
 
-            if (error.code === 'ConnectionTimeoutError') {
-              // 上传超时事件
-              this.$emit('timeout')
-            } else {
-              // 上传失败
-              this.emit('fail')
-            }
+            this.catchError(error)
           }
         } else {
           await this.client
@@ -465,24 +459,14 @@ export default {
               reset()
               this.uploading = false
 
-              // 捕获超时异常
-              if (err.code === 'ConnectionTimeoutError') {
-                /**
-                 * 上传超时事件
-                 */
-                this.$emit('timeout')
-              }
               if (this.client.isCancel()) {
                 /**
                  * 上传操作被取消事件
                  */
                 this.$emit('cancel')
-              } else {
-                /**
-                 * 上传失败事件
-                 */
-                this.$emit('fail')
               }
+
+              this.catchError(err)
             })
         }
 
@@ -529,6 +513,15 @@ export default {
     },
     removeHighlight() {
       this.isHighlight = false
+    },
+    catchError(error) {
+      if (error.code === 'ConnectionTimeoutError') {
+        // 上传超时事件
+        this.$emit('timeout')
+      } else {
+        // 上传失败
+        this.emit('fail')
+      }
     }
   }
 }

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -519,7 +519,7 @@ export default {
         this.$emit('timeout')
       } else {
         // 上传失败
-        this.emit('fail')
+        this.$emit('fail')
       }
     }
   }

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -466,7 +466,7 @@ export default {
               this.uploading = false
 
               // 捕获超时异常
-              if (e.code === 'ConnectionTimeoutError') {
+              if (err.code === 'ConnectionTimeoutError') {
                 /**
                  * 上传超时事件
                  */

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -424,9 +424,7 @@ export default {
               )
             }
           } catch (error) {
-            this.uploading = false
-
-            this.catchError(error)
+            this.handleCatchError(error)
           }
         } else {
           await this.client
@@ -457,7 +455,6 @@ export default {
             .catch(err => {
               // TODO 似乎可以干掉？🤔
               reset()
-              this.uploading = false
 
               if (this.client.isCancel()) {
                 /**
@@ -466,7 +463,7 @@ export default {
                 this.$emit('cancel')
               }
 
-              this.catchError(err)
+              this.handleCatchError(err)
             })
         }
 
@@ -514,7 +511,9 @@ export default {
     removeHighlight() {
       this.isHighlight = false
     },
-    catchError(error) {
+    handleCatchError(error) {
+      this.uploading = false
+
       if (error.code === 'ConnectionTimeoutError') {
         // 上传超时事件
         this.$emit('timeout')

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -410,16 +410,13 @@ export default {
         key = `${name.substring(0, pos)}-${new Date().getTime()}${suffix}`
 
         if (this.httpRequest) {
-          const req = this.httpRequest(e, file)
-          if (req && req.then) {
-            req.then(url => {
-              this.$emit(
-                'input',
-                this.multiple ? this.uploadList.concat(url) : url
-              )
-              currentUploads.push(url)
-            })
-          }
+          await this.httpRequest(e, file).then(url => {
+            this.$emit(
+              'input',
+              this.multiple ? this.uploadList.concat(url) : url
+            )
+            currentUploads.push(url)
+          })
         } else {
           await this.client
             .multipartUpload(this.dir + key, file, this.uploadOptions)


### PR DESCRIPTION
## Why

- 安全性问题: oss 配置信息仍可在 sources 查看
- 需求: 私有化部署上传到私有服务器, 并非 ali-oss.

## New

### props.httpRequest

## TODO

- [x] `http-request: function`
- [ ] 使用 CDN 加载 ali-oss.sdk

## How

1. 新增 `prop: http-request` 接收函数, 命名来源参考 el-upload
2. http-request 函数需要返回 promise
2.1 resolve 为上传完成, 接收 url 参数, 代表该文件 url, 用于提供组件预览.
3. 存在 http-request 则不创建 AliOSS 实例

## Test

![http-request1](https://user-images.githubusercontent.com/53422750/66697112-31584a80-ed05-11e9-8d94-dc4fe4f5fad1.gif)

模拟 http 请求, 并返回 url

## Docs

- http-request.md