### PR TITLE
fix: 图片压缩排除gif类型

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -91,13 +91,14 @@ const imageCompressor = new ImageCompressor()
 
 let doubleSlash = '//'
 let oneKB = 1024
-const image = 'image'
 const clipboardData = 'clipboardData'
 const dataTransfer = 'dataTransfer'
 const target = 'target'
 
 const mimeTypeFullRegex = /[\w]*\/[\*\w]/
 const mimeTypeHalfRegex = /[\w]*/
+
+const enableCompressRegex = /^image\/((?!gif).)+$/
 
 export default {
   name: 'UploadToAli',
@@ -397,8 +398,9 @@ export default {
          */
         this.$emit('loading', name)
 
-        if (file.type.indexOf(image) > -1)
+        if (enableCompressRegex.test(file.type)) {
           file = await imageCompressor.compress(file, this.compressOptions)
+        }
 
         //文件名-时间戳 作为上传文件key
         let pos = name.lastIndexOf('.')


### PR DESCRIPTION
## Why
Fix: #104 

## How
1. 造成gif无法正常上传原因是：压缩图片时将gif转成了png格式
2. 根据文件类型（排除gif）压缩图片


## Test

1. Before:
see #104
 
2. After:
![2019-10-28_16-09](https://user-images.githubusercontent.com/15629940/67661991-7b942980-f99d-11e9-97f8-1d335fa6ff9f.png)
![2019-10-28_16-09_1](https://user-images.githubusercontent.com/15629940/67662003-7fc04700-f99d-11e9-950b-333ab4330435.png)


