### PR TITLE
feat: 允许用户自定义处理文件大小超出size限制的逻辑

### DIFF
--- a/docs/on-oversize.md
+++ b/docs/on-oversize.md
@@ -2,7 +2,7 @@
 
 ```vue
 <template>
-  <upload-to-ali v-model="url" :onSizeOverflow="onSizeOverflow" :onWrongFormat="onWrongFormat" />
+  <upload-to-ali v-model="url" :onOversize="onOversize" :onWrongFormat="onWrongFormat" />
 </template>
 <script>
 export default {
@@ -12,7 +12,7 @@ export default {
     }
   },
   methods: {
-    onSizeOverflow() {
+    onOversize() {
       alert('所选文件大小溢出')
     },
     onWrongFormat() {

--- a/docs/on-size-overflow.md
+++ b/docs/on-size-overflow.md
@@ -1,0 +1,24 @@
+可以自定义如何处理文件大小、类型超出限制的情况（默认是alert警告）
+
+```vue
+<template>
+  <upload-to-ali v-model="url" :onSizeOverflow="onSizeOverflow" :onWrongFormat="onWrongFormat" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: ''
+    }
+  },
+  methods: {
+    onSizeOverflow() {
+      alert('所选文件大小溢出')
+    },
+    onWrongFormat() {
+      alert('所选文件类型错误')
+    },
+  }
+}
+</script>
+```

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -262,7 +262,7 @@ export default {
     /**
      * 所选文件超出size限制时的处理函数
      */
-    onSizeOverflow: {
+    onOversize: {
       type: Function,
       default() {
         const msg = `请选择${this.size}KB内的文件！`
@@ -379,10 +379,15 @@ export default {
       // 检查文件大小
       const isSizeInvalid = files.some(i => i.size > this.size * oneKB)
       if (isSizeInvalid) {
-        this.onSizeOverflow()
+        this.onOversize()
         return reset()
       }
-      // 检查文件类型
+      /**
+       * 检查文件类型
+       * FYI: input已经有accept属性，为什么还要用正则再检验一次呢？
+       * 这是因为mac和windows用户在文件选择框是可以手动选择“格式：所有文件”的
+       * 所以光用input无法保证传入的文件类型
+       */
       const isFormatInvalid =
         this.accept &&
         (this.accept.indexOf('/*') > -1

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -261,6 +261,7 @@ export default {
     },
     /**
      * 所选文件超出size限制时的处理函数
+     * @param {File} - 超出大小的文件
      */
     onOversize: {
       type: Function,
@@ -272,6 +273,7 @@ export default {
     },
     /**
      * 所选文件类型不符合accept限制时的处理函数
+     * @param {File} - 错误类型的文件
      */
     onWrongFormat: {
       type: Function,
@@ -311,7 +313,7 @@ export default {
     }
   },
   mounted() {
-    if (this.accept && !mimeTypeFullRegex.test(this.accept)) {
+    if (!mimeTypeFullRegex.test(this.accept)) {
       console.warn(
         '请设置正确的`accept`属性, 可参考:',
         'https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types'
@@ -376,27 +378,26 @@ export default {
       } catch (e) {
         return reset()
       }
-      // 检查文件大小
-      const isSizeInvalid = files.some(i => i.size > this.size * oneKB)
-      if (isSizeInvalid) {
-        this.onOversize()
+      // 检查有无oversize的文件
+      const fileOvesize = files.find(i => i.size > this.size * oneKB)
+      if (fileOvesize) {
+        this.onOversize(fileOvesize)
         return reset()
       }
       /**
-       * 检查文件类型
-       * FYI: input已经有accept属性，为什么还要用正则再检验一次呢？
-       * 这是因为mac和windows用户在文件选择框是可以手动选择“格式：所有文件”的
+       * 检查有无错误类型的文件
+       * 问: input已经有accept属性，为什么还要用正则再检验一次呢？
+       * 答：因为mac和windows用户在文件选择框是可以手动选择“格式：所有文件”的
        * 所以光用input无法保证传入的文件类型
        */
-      const isFormatInvalid =
-        this.accept &&
-        (this.accept.indexOf('/*') > -1
-          ? files.some(
+      const fileFormatInvalid =
+        this.accept.indexOf('/*') > -1
+          ? files.find(
               i => i.type.indexOf(this.accept.match(mimeTypeHalfRegex)) === -1
             )
-          : files.some(i => this.accept.indexOf(i.type) === -1))
-      if (isFormatInvalid) {
-        this.onWrongFormat()
+          : files.find(i => this.accept.indexOf(i.type) === -1)
+      if (fileFormatInvalid) {
+        this.onWrongFormat(fileFormatInvalid)
         return reset()
       }
 

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -421,13 +421,15 @@ export default {
       try {
         await this.beforeUpload(files)
       } catch (e) {
-        return reset()
+        reset()
+        return
       }
       // 检查有无oversize的文件
       const fileOvesize = files.find(i => i.size > this.size * oneKB)
       if (fileOvesize) {
         this.onOversize(fileOvesize)
-        return reset()
+        reset()
+        return
       }
       /**
        * 检查有无错误类型的文件
@@ -443,7 +445,8 @@ export default {
           : files.find(i => this.accept.indexOf(i.type) === -1)
       if (fileFormatInvalid) {
         this.onWrongFormat(fileFormatInvalid)
-        return reset()
+        reset()
+        return
       }
 
       this.uploading = true


### PR DESCRIPTION
## Why
在微信浏览器环境，alert函数会被禁止。导致丢失原来的文件大小超出size限制时的报错信息。

## How
1. 新增`onOversize`和`onWrongFormat`两个函数，允许用户自定义文件大小超出size限制或文件类型不符合accept时的处理逻辑
2. 新增`on-oversize.md`文档，演示这两个函数的用法

## Test
打开`on-oversize`示例，尝试上传大于1m的文件和非图片的文件，体验props效果

## Docs
1. api新增两个props：onOversize、onWrongFormat
2. demo新增一个示例`on-oversize`