### PR TITLE
feat: android机型支持直接唤起相册

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -298,6 +298,7 @@ export default {
       )
     }
 
+    // @see https://juejin.im/post/5af4fbeff265da0b8f6297d6
     if (/^image/.test(this.accept) && /android/i.test(navigator.userAgent)) {
       this.$refs.uploadInput.setAttribute('capture', 'camera')
     }

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -298,6 +298,10 @@ export default {
       )
     }
 
+    if (/^image/.test(this.accept) && /android/i.test(navigator.userAgent)) {
+      this.$refs.uploadInput.setAttribute('capture', 'camera')
+    }
+
     this.newClient()
   },
   methods: {


### PR DESCRIPTION
## Why
部分android机型唤起的是文件浏览器，而不是相册

## How
1. 通过`capture=camera`属性就可唤起相册。已在该部分机型上测试
2. iOS的话会直接唤起摄像头而不是相册，所以仅在android机型上添加该属性

## Test
待补充