### PR TITLE
feat: 允许用户自定义处理文件大小超出size限制的逻辑

### DIFF
--- a/docs/on-oversize.md
+++ b/docs/on-oversize.md
@@ -1,0 +1,21 @@
+可以自定义如何处理文件大小超出的情况（默认是alert警告）
+
+```vue
+<template>
+  <upload-to-ali v-model="url" :onOversize="onOversize" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: ''
+    }
+  },
+  methods: {
+    onOversize() {
+      alert('所选文件大小溢出')
+    },
+  }
+}
+</script>
+```

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -175,7 +175,7 @@ export default {
      */
     size: {
       type: Number,
-      default: oneKB
+      default: 1024
     },
     /**
      * 接受上传的文件类型, 多个值逗号分隔, 默认只接受图片
@@ -263,6 +263,16 @@ export default {
       type: Function,
       default() {
         return Promise.resolve()
+      }
+    },
+    /**
+     * 所选文件超出size限制时的处理函数；
+     * 接收超出大小的文件作为参数
+     */
+    onOversize: {
+      type: Function,
+      default() {
+        alert(`请选择${this.size}KB内的文件！`)
       }
     },
 
@@ -369,14 +379,20 @@ export default {
         reset()
         return
       }
-
-      if (files.some(i => i.size > this.size * oneKB)) {
-        // FIXME: alert不兼容微信移动端
-        alert(`请选择${this.size}KB内的文件！`)
+      // 检查有无oversize的文件
+      const fileOvesize = files.find(i => i.size > this.size * oneKB)
+      if (fileOvesize) {
+        this.onOversize(fileOvesize)
         reset()
         return
       }
 
+      /**
+       * 检查有无错误类型的文件
+       * 问: input已经有accept属性，为什么还要用正则再检验一次呢？
+       * 答：因为mac和windows用户在文件选择框是可以手动选择“格式：所有文件”的
+       * 所以光用input无法保证传入的文件类型
+       */
       if (
         this.accept &&
         (this.accept.indexOf('/*') > -1


### PR DESCRIPTION
## Why
在微信浏览器环境，alert函数会被禁止。导致丢失原来的文件大小超出size限制时的报错信息。

## How
1. 新增`onOversize`属性，允许用户自定义文件大小超出size限制时的处理逻辑
2. 新增`on-oversize.md`文档，演示这个函数的用法

## Test
打开`on-oversize`示例，尝试上传大于1m的文件，体验效果

## Docs
1. api新增一个props：onOversize
2. demo新增一个示例`on-oversize`