### PR TITLE
fix: catch compressor 报的错

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -405,7 +405,7 @@ export default {
           this.$emit('input', this.multiple ? this.uploadList.concat(url) : url)
           currentUploads.push(url)
         } catch (error) {
-          console.warn(error.message)
+          console.error('上传失败', error.message)
           /**
            * 上传失败
            * @property {Error} error - 上传失败或压缩失败抛出的 error 对象。当压缩失败时，error.message === 'compress-fail'

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -380,26 +380,26 @@ export default {
 
       const max = this.multiple ? this.max : 1
       for (let i = 0; i < files.length && this.uploadList.length < max; i++) {
-        // 尝试压缩文件
-        let file = files[i]
-        if (enableCompressRegex.test(file.type)) {
-          const blob = await new Promise((resolve, reject) => {
-            new Compressor(file, {
-              ...this.compressOptions,
-              success: resolve,
-              error: reject
-            })
-          })
-          /* eslint-disable-next-line require-atomic-updates */
-          file = new File([blob], file.name)
-        }
-        /**
-         * 上传过程中
-         * @property {string} name - 当前上传的图片名称
-         */
-        this.$emit('loading', file.name)
-
         try {
+          // 尝试压缩文件
+          let file = files[i]
+          if (enableCompressRegex.test(file.type)) {
+            const blob = await new Promise((resolve, reject) => {
+              new Compressor(file, {
+                ...this.compressOptions,
+                success: resolve,
+                error: reject
+              })
+            })
+            /* eslint-disable-next-line require-atomic-updates */
+            file = new File([blob], file.name)
+          }
+          /**
+           * 上传过程中
+           * @property {string} name - 当前上传的图片名称
+           */
+          this.$emit('loading', file.name)
+
           const url = await this.uploadRequest(file)
           if (typeof url !== 'string' || !/^(https?:)?\/\//.test(url)) {
             throw new Error(

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -381,26 +381,21 @@ export default {
       const max = this.multiple ? this.max : 1
       for (let i = 0; i < files.length && this.uploadList.length < max; i++) {
         // 尝试压缩图片
-        let file = files[i]
-        if (enableCompressRegex.test(file.type)) {
-          try {
-            file = await this.compressImg(file)
-          } catch (error) {
-            /**
-             * 图片压缩失败
-             * @property {Error} error - compressorjs 抛出的 error
-             */
-            this.$emit('compress-fail', error)
-            continue
-          }
-        }
-        /**
-         * 上传过程中
-         * @property {string} name - 当前上传的图片名称
-         */
-        this.$emit('loading', file.name)
-
         try {
+          let file = files[i]
+          if (enableCompressRegex.test(file.type)) {
+            try {
+              file = await this.compressImg(file)
+            } catch (error) {
+              throw new Error('compress-fail')
+            }
+          }
+          /**
+           * 上传过程中
+           * @property {string} name - 当前上传的图片名称
+           */
+          this.$emit('loading', file.name)
+
           const url = await this.uploadRequest(file)
           if (typeof url !== 'string' || !/^(https?:)?\/\//.test(url)) {
             throw new Error(
@@ -413,8 +408,9 @@ export default {
           console.warn(error.message)
           /**
            * 上传失败
+           * @property {Error} error - 上传失败或压缩失败抛出的 error 对象。当压缩失败时，error.message === 'compress-fail'
            */
-          this.$emit('fail')
+          this.$emit('fail', error)
         }
       }
 


### PR DESCRIPTION
## Why
fix #132 
当 compressor 接受了不能压缩的文件时，报错信息应当被 upload-to-ali 捕获

## How
1. 抽离 compress 函数
2. 包装一下 compressor 抛出的错误对象，使得用户可以区分

## Test
上传一个伪装成图片的 xmind。成功发射事件
![image](https://user-images.githubusercontent.com/19591950/70611181-bb5a5c00-1c3f-11ea-8808-04441b596c7e.png)


## Docs
![image](https://user-images.githubusercontent.com/19591950/70611192-beede300-1c3f-11ea-9542-8811aec9eca2.png)

