### PR TITLE
fix: 当已上传文件有值时，再次上传多文件可以超出max配置限制值

### DIFF
--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -388,8 +388,8 @@ export default {
       const currentUploads = []
       this.uploading = true
 
-      const max = this.multiple ? this.max : 1
-      for (let i = 0; i < files.length && this.uploadList.length < max; i++) {
+      const max = this.multiple ? (this.max- this.uploadList.length) : 1
+      for (let i = 0; i < files.length && i < max; i++) {
         // 尝试压缩图片
         try {
           let file = files[i]

--- a/src/upload-to-ali.vue
+++ b/src/upload-to-ali.vue
@@ -388,7 +388,7 @@ export default {
       const currentUploads = []
       this.uploading = true
 
-      const max = this.multiple ? (this.max- this.uploadList.length) : 1
+      const max = this.multiple ? (this.max - this.uploadList.length) : 1
       for (let i = 0; i < files.length && i < max; i++) {
         // 尝试压缩图片
         try {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
当已上传文件有值时，再次上传多文件可以超出max配置限制值

## How
Describe your steps:
1. 多文件上传时，对比现有文件数量与限制文件数量
2. 遍历上传文件时超出范围时停止文件上传遍历

